### PR TITLE
Deprecation of cross-validation: Replaced by sklearn.model_selection.

### DIFF
--- a/Natural Language Processing.ipynb
+++ b/Natural Language Processing.ipynb
@@ -35,12 +35,12 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
       "[nltk_data] Downloading package stopwords to\n",
-      "[nltk_data]     C:\\Users\\Student\\AppData\\Roaming\\nltk_data...\n",
-      "[nltk_data]   Package stopwords is already up-to-date!\n"
+      "[nltk_data]     C:\\Users\\Mateo\\AppData\\Roaming\\nltk_data...\n",
+      "[nltk_data]   Unzipping corpora\\stopwords.zip.\n"
      ]
     }
    ],
@@ -99,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -109,18 +109,10 @@
       "[[55 42]\n",
       " [12 91]]\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\Student\\Anaconda3\\lib\\site-packages\\sklearn\\cross_validation.py:44: DeprecationWarning: This module was deprecated in version 0.18 in favor of the model_selection module into which all the refactored classes and functions are moved. Also note that the interface of the new CV iterators are different from that of this module. This module will be removed in 0.20.\n",
-      "  \"This module will be removed in 0.20.\", DeprecationWarning)\n"
-     ]
     }
    ],
    "source": [
-    "from sklearn.cross_validation import train_test_split\n",
+    "from sklearn.model_selection import train_test_split\n",
     "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size = 0.20, random_state = 0)\n",
     "\n",
     "# Fitting Naive Bayes to the Training set\n",
@@ -175,7 +167,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
sklearn.cross-validation deprecated. [Stackoverflow](https://stackoverflow.com/questions/30667525/importerror-no-module-named-sklearn-cross-validation)
